### PR TITLE
Modified port selection to allow for named pipes

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -45,13 +45,13 @@ module.exports = {
      * @returns {http.Server}
      */
     app.listen = function(port) {
-      var args = _.isNumber(port) ? _.drop(arguments, 1) : _.drop(arguments, 0);
+      var args = _.isUndefined(port) ? _.drop(arguments, 1) : _.drop(arguments, 0);
 
       var httpServer = http.createServer(app);
 
       // Wait until parsing is done
       server.__parser.whenParsed(function(err, api, metadata) {
-        if (!_.isNumber(port)) {
+      if (!_.isNumber(port)) {
           // No port number was provided, so get it from the Swagger API
           var host = api ? api.host || '' : '';
           var hostMatches = host.match(/[^:]+(?:\:(\d+))?$/); // ['hostname', 'port']
@@ -61,7 +61,7 @@ module.exports = {
         }
 
         util.debug('Starting HTTP server');
-        httpServer.listen.apply(httpServer, [port].concat(args));
+        httpServer.listen.apply(httpServer, _.union([port], args));
       });
 
       return httpServer;


### PR DESCRIPTION
Changed the listen function not to just check for ports as numbers but
to allow for named pipes which appear as strings to be used.  In the
scenario that the swagger-server is used within the Azure WebApp the
swagger specification host entry can not be used to determine the port
number.  Specifically the scenario that the changes address is the
following:

_server.js_
```javascript
var port = process.env.port || 1337;
app.listen(port, function () {
```
_swagger spec_
```javascript
swagger: "2.0"
info:
  version: 1.0.0
  title: Swagger petstore
  description: A sample API that demonstrates Swagger Server features

#host: petstore.swagger.io:8000

consumes:

  - application/json
produces:
  - application/json
```
