### PR TITLE
Reorder CORS to come before files

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -94,8 +94,8 @@ module.exports = {
     swaggerRouter.use(
       poweredBy,
       server.__middleware.metadata(),
-      server.__middleware.files(),
       server.__middleware.CORS(),
+      server.__middleware.files(),
       server.__middleware.parseRequest(),
       server.__middleware.validateRequest()
     );


### PR DESCRIPTION
This ensures that the API docs get CORS headers as well, allowing
them to work with tools like Swagger UI.