### PR TITLE
fix nodejs 6.x error with resolving path from object

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -59,7 +59,10 @@ SwaggerParser.prototype.parse = function(swagger) {
     //f Emit a "parsed" event, regardless of whether there was an error
     util.debug('Done parsing Swagger file "%s"', swagger);
 
-    var basePath = path.dirname(swagger);
+    var basePath = "";
+    if(swagger instanceof String) {
+        var basePath = path.dirname(swagger);
+    }
     self.server.emit('parsed', err, api, parser, basePath);
   });
 };


### PR DESCRIPTION
an error started to apper when parsing swagger API from JSON object like this with new nodejs 6.9.1:

```
parser.dereference("swagger.yaml", {
    $refs: {
        internal: false
    }
}).then(function (api) {
    server.parse(api);
    server.listen(1000, function () {
        console.log('Your REST API is now running at http://localhost:1000');
    });
});
```
path.dirname() in parser.js throws errors when passed an object instead of string.

I needed to divide API docs into smaller files and I wanted to use refs without filename to generate one single JSON back from.